### PR TITLE
amber-tabs: removed grey bottom line on Firefox

### DIFF
--- a/src/components/tabs/style.scss
+++ b/src/components/tabs/style.scss
@@ -12,7 +12,7 @@ ul.tabs-list {
   box-shadow: inset 0 -1px 0 0 $grey-light;
   display: flex;
   list-style: none;
-  overflow-x: scroll;
+  overflow-x: auto;
 
   &::-webkit-scrollbar {
     display: none;


### PR DESCRIPTION
Resolved #31.
This bug initially didn't appear on my machine (MacBook Pro Mid 2015, Mojave 10.14.3, Firefox 65). Tried on Firefox 64 on Mojave only on BrowserStack and it works now.